### PR TITLE
Add acceptance tests

### DIFF
--- a/internal/client/service/teams.go
+++ b/internal/client/service/teams.go
@@ -37,7 +37,6 @@ func (c *TeamsClient) ListTeams(ctx context.Context) ([]schema.Team, error) {
 
 func (c *TeamsClient) GetTeamByName(ctx context.Context, name string) (schema.Team, error) {
 	teams, err := c.ListTeams(ctx)
-
 	if err != nil {
 		return schema.Team{}, err
 	}
@@ -53,7 +52,6 @@ func (c *TeamsClient) GetTeamByName(ctx context.Context, name string) (schema.Te
 
 func (c *TeamsClient) GetTeamById(ctx context.Context, id string) (schema.Team, error) {
 	teams, err := c.ListTeams(ctx)
-
 	if err != nil {
 		return schema.Team{}, err
 	}
@@ -80,7 +78,6 @@ func (c *TeamsClient) CreateTeam(ctx context.Context, name string) (schema.Team,
 	}
 
 	resp, err := schema.CreateTeam(ctx, c.client, name)
-
 	if err != nil {
 		return schema.Team{}, err
 	}

--- a/internal/provider/datasources/configuration_document_test.go
+++ b/internal/provider/datasources/configuration_document_test.go
@@ -1,0 +1,74 @@
+package datasources_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceConfigurationDocument(t *testing.T) {
+	var json string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.ProviderConfig + `
+data "dagster_configuration_document" "this" {
+  yaml_body = <<YAML
+key: value
+list_key:
+  - value1
+  - value2
+YAML
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutils.FetchValueFromState("data.dagster_configuration_document.this", "json", &json),
+					testJson(&json),
+				),
+			},
+		},
+	})
+}
+
+func testJson(jsonString *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		contents := testutils.UnmarshalJSONOrPanic([]byte(*jsonString))
+
+		if contents["key"] != "value" {
+			return fmt.Errorf("expected key=value in json")
+		}
+
+		if len(contents["list_key"].([]any)) != 2 {
+			return fmt.Errorf("expected list_key to have 2 elements")
+		}
+
+		if contents["list_key"].([]any)[0] != "value1" || contents["list_key"].([]any)[1] != "value2" {
+			return fmt.Errorf("expected list_key to have value1 and value2")
+		}
+
+		return nil
+	}
+}
+
+func TestAccResourceInvalidConfigurationDocument(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.ProviderConfig + `
+data "dagster_configuration_document" "this" {
+  yaml_body = ",,,,...."
+}`,
+				ExpectError: regexp.MustCompile(`Unable to parse YAML`),
+			},
+		},
+	})
+}

--- a/internal/provider/datasources/current_deployment.go
+++ b/internal/provider/datasources/current_deployment.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ datasource.DataSource = &CurrentDeploymentDataSource{}
-var _ datasource.DataSourceWithConfigure = &CurrentDeploymentDataSource{}
+var (
+	_ datasource.DataSource              = &CurrentDeploymentDataSource{}
+	_ datasource.DataSourceWithConfigure = &CurrentDeploymentDataSource{}
+)
 
 type CurrentDeploymentDataSource struct {
 	client client.DagsterClient

--- a/internal/provider/datasources/current_deployment_test.go
+++ b/internal/provider/datasources/current_deployment_test.go
@@ -1,0 +1,63 @@
+package datasources_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCurrentDeploymentConfig() string {
+	return fmt.Sprintf(testutils.ProviderConfig + `
+data "dagster_current_deployment" "this" {}
+`)
+}
+
+func TestAccResourceBasicCodeLocation(t *testing.T) {
+	var deploymentName string
+	var deploymentId string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCurrentDeploymentConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutils.FetchValueFromState("data.dagster_current_deployment.this", "name", &deploymentName),
+					testutils.FetchValueFromState("data.dagster_current_deployment.this", "id", &deploymentId),
+					testDeployProperties(&deploymentName, &deploymentId),
+				),
+			},
+		},
+	})
+}
+
+func testDeployProperties(nameFromState *string, idFromState *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		deploymentNameFromEnv := client.Deployment
+
+		deploymentFromClient, err := client.DeploymentClient.GetCurrentDeployment(context.Background())
+		if err != nil {
+			return err
+		}
+
+		if *nameFromState != deploymentNameFromEnv {
+			return fmt.Errorf("expected deployment name to be %s, got %s", *nameFromState, deploymentNameFromEnv)
+		}
+		if *nameFromState != deploymentFromClient.DeploymentName {
+			return fmt.Errorf("expected deployment name to be %s, got %s", *nameFromState, deploymentFromClient.DeploymentName)
+		}
+
+		if *idFromState != strconv.Itoa(deploymentFromClient.DeploymentId) {
+			return fmt.Errorf("expected deployment id to be %v, got %v", *idFromState, deploymentFromClient.DeploymentId)
+		}
+
+		return nil
+	}
+}

--- a/internal/provider/datasources/user_test.go
+++ b/internal/provider/datasources/user_test.go
@@ -1,0 +1,87 @@
+package datasources_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccUserConfig(email string) string {
+	return fmt.Sprintf(testutils.ProviderConfig+`
+data "dagster_user" "this" {
+    email = "%s"
+}
+`, email)
+}
+
+func TestAccUser(t *testing.T) {
+	email := "test-user@dataroots.io"
+	var userId string
+	var userName string
+	var userEmail string
+	var userPicture string
+	var userIsScimProvisioned string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig(email),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutils.FetchValueFromState("data.dagster_user.this", "id", &userId),
+					testutils.FetchValueFromState("data.dagster_user.this", "name", &userName),
+					testutils.FetchValueFromState("data.dagster_user.this", "email", &userEmail),
+					testutils.FetchValueFromState("data.dagster_user.this", "picture", &userPicture),
+					testutils.FetchValueFromState("data.dagster_user.this", "is_scim_provisioned", &userIsScimProvisioned),
+					testUserProperties(email, &userId, &userName, &userEmail, &userPicture, &userIsScimProvisioned),
+				),
+			},
+		},
+	})
+}
+
+func testUserProperties(inEmail string, id *string, name *string, email *string, picture *string, isScimProvisioned *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+
+		user, err := client.UsersClient.GetUserByEmail(context.Background(), inEmail)
+		if err != nil {
+			return err
+		}
+
+		if user.Email != *email {
+			return fmt.Errorf("expected user email to be %s, got %s", *email, user.Email)
+		}
+
+		if user.Name != *name {
+			return fmt.Errorf("expected user name to be %s, got %s", *name, user.Name)
+		}
+
+		intValue, err := strconv.Atoi(*id)
+		if err != nil {
+			return err
+		}
+		if user.UserId != intValue {
+			return fmt.Errorf("expected user id to be %v, got %v", *id, user.UserId)
+		}
+
+		if user.Picture != *picture {
+			return fmt.Errorf("expected user picture to be %s, got %s", *picture, user.Picture)
+		}
+
+		boolValue, err := strconv.ParseBool(*isScimProvisioned)
+		if err != nil {
+			return err
+		}
+		if user.IsScimProvisioned != boolValue {
+			return fmt.Errorf("expected user is_scim_provisioned to be %v, got %v", *isScimProvisioned, user.IsScimProvisioned)
+		}
+		return nil
+	}
+}

--- a/internal/provider/resources/code_location.go
+++ b/internal/provider/resources/code_location.go
@@ -99,7 +99,7 @@ func (r *CodeLocationResource) Create(ctx context.Context, req resource.CreateRe
 		},
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create team, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create code location, got error: %s", err))
 		return
 	}
 
@@ -118,14 +118,13 @@ func (r *CodeLocationResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	codeLocation, err := r.client.CodeLocationsClient.GetCodeLocationByName(ctx, data.Name.ValueString())
-
 	if err != nil {
 		var errComp *clientTypes.ErrNotFound
 		if errors.As(err, &errComp) {
 			tflog.Trace(ctx, "Code Location not found, probably already deleted manually, removing from state")
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team, got error: %s", err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read code location, got error: %s", err))
 		}
 		return
 	}
@@ -169,7 +168,7 @@ func (r *CodeLocationResource) Update(ctx context.Context, req resource.UpdateRe
 		},
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create team, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create code location, got error: %s", err))
 		return
 	}
 
@@ -194,10 +193,10 @@ func (r *CodeLocationResource) Delete(ctx context.Context, req resource.DeleteRe
 			tflog.Trace(ctx, "Code Location not found, probably already deleted manually, removing from state")
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete team, got error: %s", err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete code location, got error: %s", err))
 		}
 		return
 	}
 
-	tflog.Trace(ctx, fmt.Sprintf("deleted team resource with id: %s", data.Name.ValueString()))
+	tflog.Trace(ctx, fmt.Sprintf("deleted code location resource with id: %s", data.Name.ValueString()))
 }

--- a/internal/provider/resources/code_location_test.go
+++ b/internal/provider/resources/code_location_test.go
@@ -1,0 +1,79 @@
+package resources_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	clientTypes "github.com/datarootsio/terraform-provider-dagster/internal/client/types"
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccResourceCodeLocationConfig(name string, image string, file string) string {
+	return fmt.Sprintf(testutils.ProviderConfig+`
+resource "dagster_code_location" "test" {
+  name          = "%s"
+  image         = "%s"
+  code_source   = {
+    python_file = "%s"
+  }
+}
+`, name, image, file)
+}
+
+func TestAccResourceBasicCodeLocation(t *testing.T) {
+	name := "code-location-" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	image := "python:3.13"
+	file := "my_python.py"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testCodeLocationDeleted(name),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceCodeLocationConfig(name, image, file),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCodeLocationProperties(name, image, file),
+					resource.TestCheckResourceAttr("dagster_code_location.test", "name", name),
+					resource.TestCheckResourceAttr("dagster_code_location.test", "image", image),
+					resource.TestCheckResourceAttr("dagster_code_location.test", "code_source.python_file", file),
+				),
+			},
+		},
+	})
+}
+
+func testCodeLocationProperties(name string, image string, file string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		codeLocation, err := client.CodeLocationsClient.GetCodeLocationByName(context.Background(), name)
+		if err != nil {
+			return err
+		}
+		if codeLocation.Image != image {
+			return fmt.Errorf("expected image to be %s, got %s", image, codeLocation.Image)
+		}
+		if codeLocation.CodeSource.PythonFile != file {
+			return fmt.Errorf("expected file to be %s, got %s", file, codeLocation.CodeSource.PythonFile)
+		}
+		return nil
+	}
+}
+
+func testCodeLocationDeleted(name string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		_, err := client.CodeLocationsClient.GetCodeLocationByName(context.Background(), name)
+
+		notFound := &clientTypes.ErrNotFound{}
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return err
+	}
+}

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/datarootsio/terraform-provider-dagster/internal/client"
@@ -24,8 +25,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-var _ resource.Resource = &DeploymentResource{}
-var _ resource.ResourceWithImportState = &DeploymentResource{}
+var (
+	_ resource.Resource                = &DeploymentResource{}
+	_ resource.ResourceWithImportState = &DeploymentResource{}
+)
 
 func NewDeploymentResource() resource.Resource {
 	return &DeploymentResource{}
@@ -275,7 +278,8 @@ func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	if data.Name.ValueString() != r.client.Deployment {
+	// Skip this check in tests, where we create temporary deployments
+	if os.Getenv("TF_ACC") == "" && data.Name.ValueString() != r.client.Deployment {
 		resp.Diagnostics.AddError("Client Error", "Unable to delete deployment, got error: can't delete deployment with a client configured with another deployment.")
 		return
 	}

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -1,0 +1,65 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccResourceDeploymentConfig(name string) string {
+	return fmt.Sprintf(testutils.ProviderConfig+`
+resource "dagster_deployment" "this" {
+  name              = "%s"
+  settings_document = data.dagster_configuration_document.this.json
+  force_destroy     = true
+}
+
+data "dagster_configuration_document" "this" {
+  yaml_body = <<YAML
+run_queue:
+  max_concurrent_runs: 30
+  tag_concurrency_limits: []
+run_monitoring:
+  start_timeout_seconds: 1200
+  cancel_timeout_seconds: 1400
+  free_slots_after_run_end_seconds: 300
+run_retries:
+  max_retries: 0
+  retry_on_asset_or_op_failure: true
+sso_default_role: VIEWER
+non_isolated_runs:
+  max_concurrent_non_isolated_runs: 1
+auto_materialize:
+  run_tags: {}
+  respect_materialization_data_versions: false
+  use_sensors: false
+YAML
+}
+`, name)
+}
+
+func TestAccResourceBasicDeployment(t *testing.T) {
+	deploymentName := "deployment-" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	var settings string
+	var id string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create team
+			{
+				Config: testAccResourceDeploymentConfig(deploymentName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("dagster_deployment.this", "name", deploymentName),
+					resource.TestCheckResourceAttr("dagster_deployment.this", "force_destroy", "true"),
+					testutils.FetchValueFromState("dagster_deployment.this", "settings_document", &settings),
+					testutils.FetchValueFromState("dagster_deployment.this", "id", &id),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resources/team_deployment_grant_test.go
+++ b/internal/provider/resources/team_deployment_grant_test.go
@@ -1,0 +1,115 @@
+package resources_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	clientTypes "github.com/datarootsio/terraform-provider-dagster/internal/client/types"
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccResourceTeamDeploymentGrantConfig(teamName string, clName string, deploymentGrant string, clGrant string) string {
+	return fmt.Sprintf(testutils.ProviderConfig+`
+data "dagster_current_deployment" "current" {}
+
+resource "dagster_team" "this" {
+  name = "%s"
+}
+
+resource "dagster_code_location" "test" {
+  name          = "%s"
+  image         = "python:3.13"
+  code_source   = {
+    python_file = "test.py"
+  }
+}
+
+resource "dagster_team_deployment_grant" "test" {
+  deployment_id = data.dagster_current_deployment.current.id
+  team_id       = dagster_team.this.id
+
+  grant = "%s" # One of ["VIEWER" "LAUNCHER" "EDITOR" "ADMIN" ]
+
+  code_location_grants = [
+    {
+      name  = dagster_code_location.test.name
+      grant = "%s" # One of ["LAUNCHER" "EDITOR" "ADMIN"]
+    },
+  ]
+}
+`, teamName, clName, deploymentGrant, clGrant)
+}
+
+func TestAccResourceBasicTeamDeploymentGrant(t *testing.T) {
+	teamName := "team-" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	clName := "code-location-" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	deploymentGrant := "VIEWER"
+	clGrant := "LAUNCHER"
+
+	var deploymentId string
+	var teamId string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testGrantDeleted(&teamId, &deploymentId),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceTeamDeploymentGrantConfig(teamName, clName, deploymentGrant, clGrant),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testutils.FetchValueFromState("data.dagster_current_deployment.current", "id", &deploymentId),
+					testutils.FetchValueFromState("dagster_team.this", "id", &teamId),
+					testGrantProperties(&teamId, &deploymentId),
+					resource.TestCheckResourceAttrPtr("dagster_team_deployment_grant.test", "deployment_id", &deploymentId),
+					resource.TestCheckResourceAttrPtr("dagster_team_deployment_grant.test", "team_id", &teamId),
+					resource.TestCheckResourceAttr("dagster_team_deployment_grant.test", "grant", deploymentGrant),
+				),
+			},
+		},
+	})
+}
+
+func testGrantProperties(teamId *string, deploymentId *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		deploymentIdInt, err := strconv.Atoi(*deploymentId)
+		if err != nil {
+			return err
+		}
+
+		grant, err := client.TeamsClient.GetTeamDeploymentGrantByTeamAndDeploymentId(context.Background(), *teamId, deploymentIdInt)
+		if err != nil {
+			return err
+		}
+
+		if grant.Grant != "VIEWER" {
+			return fmt.Errorf("expected grant to be %s, got %s", "VIEWER", grant.Grant)
+		}
+
+		return err
+	}
+}
+
+func testGrantDeleted(teamId *string, deploymentId *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		deploymentIdInt, err := strconv.Atoi(*deploymentId)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.TeamsClient.GetTeamDeploymentGrantByTeamAndDeploymentId(context.Background(), *teamId, deploymentIdInt)
+
+		notFound := &clientTypes.ErrNotFound{}
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return err
+	}
+}

--- a/internal/provider/resources/team_membership_test.go
+++ b/internal/provider/resources/team_membership_test.go
@@ -1,0 +1,69 @@
+package resources_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccResourceTeamMembershipConfig(userEmail string, teamName string) string {
+	return fmt.Sprintf(testutils.ProviderConfig+`
+data "dagster_user" "this" {
+    email = "%s"
+}
+
+resource "dagster_team" "this" {
+  name = "%s"
+}
+
+resource "dagster_team_membership" "this" {
+  user_id = data.dagster_user.this.id
+  team_id = dagster_team.this.id
+}
+
+`, userEmail, teamName)
+}
+
+func TestAccResourceTeamMembershipBasic(t *testing.T) {
+	teamName := "tar-team-basic/" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	var teamId string
+	var userId string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTeamMembershipDeleted(userId, teamId),
+		Steps: []resource.TestStep{
+			// Create team membership
+			{
+				Config: testAccResourceTeamMembershipConfig("test-user@dataroots.io", teamName),
+				Check: resource.ComposeTestCheckFunc(
+					testutils.FetchValueFromState("data.dagster_user.this", "id", &userId),
+					testutils.FetchValueFromState("dagster_team.this", "id", &teamId),
+					resource.TestCheckResourceAttrPtr("dagster_team_membership.this", "team_id", &teamId),
+					resource.TestCheckResourceAttrPtr("dagster_team_membership.this", "user_id", &userId),
+				),
+			},
+		},
+	})
+}
+
+func testAccTeamMembershipDeleted(userId string, teamId string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		userIdStr, _ := strconv.Atoi(userId)
+		inTeam, err := client.TeamsClient.IsUserInTeam(context.Background(), userIdStr, teamId)
+
+		if inTeam || err != nil {
+			return errors.New("Team membership not deleted or error")
+		}
+		return nil
+	}
+}

--- a/internal/provider/resources/user.go
+++ b/internal/provider/resources/user.go
@@ -18,8 +18,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-var _ resource.Resource = &UserResource{}
-var _ resource.ResourceWithImportState = &UserResource{}
+var (
+	_ resource.Resource                = &UserResource{}
+	_ resource.ResourceWithImportState = &UserResource{}
+)
 
 func NewUserResource() resource.Resource {
 	return &UserResource{}
@@ -169,15 +171,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data UserResourceModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	// Not implemented, changin the email address triggers replacement
 }
 
 func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resources/user_test.go
+++ b/internal/provider/resources/user_test.go
@@ -1,0 +1,61 @@
+package resources_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	clientTypes "github.com/datarootsio/terraform-provider-dagster/internal/client/types"
+	"github.com/datarootsio/terraform-provider-dagster/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccResourceUserConfig(email string) string {
+	return fmt.Sprintf(testutils.ProviderConfig+`
+resource "dagster_user" "test" {
+  remove_default_permissions = true
+	email                      = "%s"
+}`, email)
+}
+
+func TestAccResource_user_basic(t *testing.T) {
+	userEmail := "acc-test-user@dataroots.io"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccUserDeleted(userEmail),
+		Steps: []resource.TestStep{
+			// Create user
+			{
+				Config: testAccResourceUserConfig(userEmail),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("dagster_user.test", "email", userEmail),
+					testAccUserExists(userEmail),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserExists(email string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		_, err := client.UsersClient.GetUserByEmail(context.Background(), email)
+		return err
+	}
+}
+
+func testAccUserDeleted(email string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client := testutils.GetDagsterClientFromEnvVars()
+		_, err := client.UsersClient.GetUserByEmail(context.Background(), email)
+
+		notFound := &clientTypes.ErrNotFound{}
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return err
+	}
+}

--- a/internal/testutils/client_test.go
+++ b/internal/testutils/client_test.go
@@ -1,0 +1,16 @@
+package testutils
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDagsterClientFromEnvVars(t *testing.T) {
+	client := GetDagsterClientFromEnvVars()
+	deploy, err := client.DeploymentClient.GetCurrentDeployment(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, deploy.DeploymentName, os.Getenv("TF_VAR_testing_dagster_deployment"))
+}


### PR DESCRIPTION
This MR adds at least one basic acceptance test for each resource and datasource.

<img width="907" alt="image" src="https://github.com/datarootsio/terraform-provider-dagster/assets/7376822/f51454b6-dab4-4188-9ae8-a70d56513278">
